### PR TITLE
Api to add player to team mapping

### DIFF
--- a/server/api/map/index.js
+++ b/server/api/map/index.js
@@ -11,17 +11,10 @@ router.route('/')
 	})
 	.get(controller.index);
 
-// 	.post(controller.create);
-
-
-
-// router.route('/:team_id')
-// 	.all(function(req, res, next) {
-// 	  next();
-// 	})
-// 	.get(controller.read)
-// 	.put(controller.update)
-// 	.delete(controller.delete);	
-
+router.route('/:playerEmail/:teamName')
+	.all(function(req, res, next){
+		next();
+	})
+	.post(controller.update);
 
 module.exports = router;

--- a/server/api/map/index.js
+++ b/server/api/map/index.js
@@ -15,6 +15,6 @@ router.route('/:playerEmail/:teamName')
 	.all(function(req, res, next){
 		next();
 	})
-	.post(controller.update);
+	.put(controller.update);
 
 module.exports = router;

--- a/server/api/map/maps.controller.js
+++ b/server/api/map/maps.controller.js
@@ -24,33 +24,33 @@ exports.index = function(req, res) {
 exports.update = function(req, res) {
 	var teamName = req.params.teamName;
 	var playerEmail = req.params.playerEmail;
-	var failure = function(err) {console.log(err);};
+	
+	var dbCallFailure = function(err) {
+		res.status(409).json({message: 'An unexpected application error has occured.  Please try again.'});
+	};
+	
+	var badInputFailure = function(errorText) {
+		res.status(400).json({message: errorText});
+	};
 
-	// console.log('About to call find by email:');
 	players.findByEmail(playerEmail, function(player) {
-		// console.log("Here with player: " + JSON.stringify(player, null, "  "));
+		if (!player) {
+			badInputFailure('The provided playerEmail (' + playerEmail + ') does not exist.');
+			return;
+		};
+
 		teams.findByName(teamName, function(team) {
-			// console.log("Here with team: " + JSON.stringify(team, null, "  "));
+			if (!team) {
+				badInputFailure('The provided teamName (' + teamName + ') does not exist.');
+				return;
+			};
+
 			player._team = team;
 			player.save(function(err, updatedPlayer) {
-				// console.log("Here with updated player: " + JSON.stringify(updatedPlayer, null, "  "));
 				maps.buildTeamPlayersMap(function(result) {
-					// console.log("Here with result: " + JSON.stringify(result, null, "  "));
 					res.json(result);
 				});
-			}, failure);
-		}, failure);
-	}, failure);
-
-
-	//TODO - 
-	// get the player 
-	// get the team
-	// add the team to the player (overwriting if another team connection exists ?)
-	// save it to mongo
-	// ? return the new map?
-	// what if an error happens inside of the save function?  - probably need some kind of err check and call the failure function
-
-	// ? need a DELETE function for a mapping ?
-
+			}, dbCallFailure);
+		}, dbCallFailure);
+	}, dbCallFailure);
 };

--- a/server/api/map/maps.controller.js
+++ b/server/api/map/maps.controller.js
@@ -12,10 +12,45 @@
 var _ = require('lodash');
 
 var maps = require("../../components/maps");
-// Get list of players
+var players = require('../../components/players');
+var teams = require('../../components/teams');
 
 exports.index = function(req, res) {
 	maps.buildTeamPlayersMap(function(result) {
 		res.json(result);
 	});
+};
+
+exports.update = function(req, res) {
+	var teamName = req.params.teamName;
+	var playerEmail = req.params.playerEmail;
+	var failure = function(err) {console.log(err);};
+
+	console.log('About to call find by email:');
+	players.findByEmail(playerEmail, function(player) {
+		console.log("Here with player: " + JSON.stringify(player, null, "  "));
+		teams.findByName(teamName, function(team) {
+			console.log("Here with team: " + JSON.stringify(team, null, "  "));
+			player._team = team;
+			player.save(function(err, updatedPlayer) {
+				console.log("Here with updated player: " + JSON.stringify(updatedPlayer, null, "  "));
+				maps.buildTeamPlayersMap(function(result) {
+					console.log("Here with result: " + JSON.stringify(result, null, "  "));
+					res.json(result);
+				});
+			}, failure);
+		}, failure);
+	}, failure);
+
+
+	//TODO - 
+	// get the player 
+	// get the team
+	// add the team to the player (overwriting if another team connection exists ?)
+	// save it to mongo
+	// ? return the new map?
+	// what if an error happens inside of the save function?  - probably need some kind of err check and call the failure function
+
+	// ? need a DELETE function for a mapping ?
+
 };

--- a/server/api/map/maps.controller.js
+++ b/server/api/map/maps.controller.js
@@ -26,16 +26,16 @@ exports.update = function(req, res) {
 	var playerEmail = req.params.playerEmail;
 	var failure = function(err) {console.log(err);};
 
-	console.log('About to call find by email:');
+	// console.log('About to call find by email:');
 	players.findByEmail(playerEmail, function(player) {
-		console.log("Here with player: " + JSON.stringify(player, null, "  "));
+		// console.log("Here with player: " + JSON.stringify(player, null, "  "));
 		teams.findByName(teamName, function(team) {
-			console.log("Here with team: " + JSON.stringify(team, null, "  "));
+			// console.log("Here with team: " + JSON.stringify(team, null, "  "));
 			player._team = team;
 			player.save(function(err, updatedPlayer) {
-				console.log("Here with updated player: " + JSON.stringify(updatedPlayer, null, "  "));
+				// console.log("Here with updated player: " + JSON.stringify(updatedPlayer, null, "  "));
 				maps.buildTeamPlayersMap(function(result) {
-					console.log("Here with result: " + JSON.stringify(result, null, "  "));
+					// console.log("Here with result: " + JSON.stringify(result, null, "  "));
 					res.json(result);
 				});
 			}, failure);

--- a/server/api/map/maps.controller.spec.js
+++ b/server/api/map/maps.controller.spec.js
@@ -114,7 +114,7 @@ describe('/api/maps/:playerEmail/:teamName', function() {
 
   var performUpdateAndCheck = function(playerEmail, teamName, expected, done) {
     request(app)
-      .post('/api/maps/' + playerEmail + '/' + teamName)
+      .put('/api/maps/' + playerEmail + '/' + teamName)
       .expect(200)
       .expect('Content-Type', /json/)
       .end(function(err, res) {
@@ -129,7 +129,7 @@ describe('/api/maps/:playerEmail/:teamName', function() {
 
   var performUpdateAndCheckForError = function(playerEmail, teamName, expected, errorCode, done) {
     request(app)
-      .post('/api/maps/' + playerEmail + '/' + teamName)
+      .put('/api/maps/' + playerEmail + '/' + teamName)
       .expect(errorCode)
       .expect('Content-Type', /json/)
       .end(function(err, res) {

--- a/server/components/teams.js
+++ b/server/components/teams.js
@@ -19,9 +19,20 @@ module.exports = (function() {
   TeamSchema.plugin(tree);
   var _model = mongoose.model('Team', TeamSchema);
 
+  var _findByName = function(teamName, successCB, errorCB) {
+    _model.findOne(
+      {
+        name: teamName
+      },
+      function(err, doc) {
+        err ? errorCB(err) : successCB(doc);
+      }
+    )
+  };
 
   return {
     Team: _model,
     schema: TeamSchema,
+    findByName: _findByName
   }
 })();

--- a/server/components/teams.spec.js
+++ b/server/components/teams.spec.js
@@ -13,6 +13,7 @@
 var mongoose = require("mongoose");
 var teams = require("./teams");
 var should = require('should');
+var assert = require('assert');
 var config = require('../config/environment/test');
 
 var dataService = require('./dataService')
@@ -20,8 +21,10 @@ var dataService = require('./dataService')
 dataService.connect();
 
 describe("In the components/teams module,", function() {
-    describe('a Team', function() {
+
+    describe('a Team ', function() {
         var theTeam = null;
+        
         beforeEach(function(done) {
             teams.Team.create({
                 name: "Ford"
@@ -40,6 +43,7 @@ describe("In the components/teams module,", function() {
                 doc.name.should.eql(theTeam.name);
             });
         });
+        
         it("that is unique ", function() {
             var teamFailed = new teams.Team();
             teamFailed.name = theTeam.name;
@@ -48,6 +52,7 @@ describe("In the components/teams module,", function() {
                 (11000).should.eql(err.code);
             });
         });
+        
         it("contains other teams", function() {
 
             var subTeam = new teams.Team();
@@ -60,6 +65,44 @@ describe("In the components/teams module,", function() {
                 });
             });
         });
+        
+        it('can be searched for by the team Name.', function(done) {
+            var success = function(returnedTeam){ 
+                returnedTeam.name.should.equal(theTeam.name);
+                returnedTeam.id.should.equal(theTeam.id);
+                returnedTeam.path.should.equal(theTeam.path); 
+                done();
+            };
+
+            teams.findByName('Ford', success);
+        });
+
+        it('when searched for with a name that does not exist returns null.', function(done) {
+            var success = function(returnedTeam){ 
+                assert.equal(returnedTeam, null);
+                done();
+            };
+
+            teams.findByName('Unknown team', success);
+        }); 
+
+        it('when searched, calls the error callback function if an error is returned from the DB.', function(done) {
+            var success = function(returnedTeam){
+                fail();
+            };
+            var error = function(error){
+                done();
+            };
+            mockTheDatabase_ToReturnAnError();
+            teams.findByName('Expecting error', success, error);
+        }); 
+
+        var mockTheDatabase_ToReturnAnError = function() {
+            mongoose.Model.findOne = function(modelObject, callback){
+                callback('Hi this is the error', undefined);
+            }; 
+        };
+
         afterEach(function(done) {
             teams.Team.remove({}, function() {
                 done();


### PR DESCRIPTION
I have been working on a simple api to add a player to a team.  The approach I took was to put some working code out (without getting any detailed requirements from you), which can be used as a starting point for discussing any changes that you all would like to make.  If there is anything you want done differently, let's discuss it and I can make the changes before you accept the pull request.

Here is what a curl request to add an existing player (Harry Potter) to an existing team (Gryffindor) looks like with this new code:

curl -X PUT http://localhost:9000/api/maps/harry.potter@hogwarts.com/Gryffindor

I chose a PUT function to the maps api - since the thing we are really doing is updating the mapping between players and teams (not really a team object or a player object).  It also seems that this approach could work quite well with the UI: updating a player/team mapping (maybe by dragging and dropping a player to a new team) will return the complete new mapping which we can then use to re-render the changes in the UI.  I am open to moving it to a different endpoint though if you collectively think it belongs somewhere else.

I am using the player email and team name as parameters, since they are unique and human-readable (unlike the ids which are not very readable), and using them will make scripting team creation much easier.

I'll see what I can do tomorrow to put together a curl script that we can use to build a few teams up.

